### PR TITLE
fix(ci): disable full Renovate on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,5 +48,5 @@ jobs:
     with:
       autodiscover: false
       branch: ${{ github.head_ref }}
-      dry_run: false
+      dry_run: ${{ github.event_name == 'pull_request' && true }}
       print_config: ${{ github.event_name == 'pull_request' && true }}


### PR DESCRIPTION
Investigate the reason for Renovate autoclosing its own PRs when performing a full Renovate.