### PR TITLE
feat: Add `RENOVATE_BRANCH_PREFIX` (#467)

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -210,6 +210,7 @@ jobs:
           LOG_LEVEL: ${{ steps.configure.outputs.log-level }}
           RENOVATE_AUTODISCOVER: ${{ steps.configure.outputs.autodiscover }}
           RENOVATE_BASE_BRANCHES: ${{ steps.configure.outputs.base-branches }}
+          RENOVATE_BRANCH_PREFIX: 'renovate-github/'
           RENOVATE_USE_BASE_BRANCH_CONFIG: ${{ steps.configure.outputs.base-branches && 'merge' || 'none' }}
           RENOVATE_CACHE_NPM_MINUTES: 30
           RENOVATE_CONFIG: ${{ steps.configure.outputs.global-config }}


### PR DESCRIPTION
This commit adds the `RENOVATE_BRANCH_PREFIX` variable to the GitHub workflow file `renovate.yaml`. This new variable allows the configuration of a branch prefix for Renovate, specifically set to 'renovate-github/'. This change is work-in-progress for issue #467.