### PR TITLE
fix: pin `semantic-release` to a slightly older version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,4 +44,4 @@ jobs:
         run: |
           # Run `semantic-release`
           npm install conventional-changelog-conventionalcommits
-          npx semantic-release -- ${{ github.event.inputs.dry_run && '--dry-run' || '' }}
+          npx semantic-release@21.0.1 -- ${{ github.event.inputs.dry_run && '--dry-run' || '' }}


### PR DESCRIPTION
This is an attempt to workaround semantic-release/release-notes-generator#459.