### PR TITLE
fix(default): remove 'v' prefix from `regex` manager version strings

### DIFF
--- a/default.json
+++ b/default.json
@@ -22,6 +22,12 @@
       "description": "Enable major version updates for Docker images and pin digests in Dockerfiles and docker-compose.yml",
       "extends": ["docker:enableMajor", "docker:pinDigests"],
       "matchManagers": ["dockerfile", "docker-compose"]
+    },
+    {
+      "description": "Remove 'v' prefix from `regex` manager version strings",
+      "matchManagers": ["regex"],
+      "extractVersion": "^?v?(?<version>\\d+\\.\\d+\\.\\d+.*)$",
+      "versioning": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+.*))?$"
     }
   ],
   "customManagers": [

--- a/vendors.json
+++ b/vendors.json
@@ -30,7 +30,7 @@
         "matchStrings": [
           "[\"']github>(?<depName>bfra-me\\/renovate-config)(?:(?::|\\/\\/)(?<path>.+?))?#(?<currentValue>.+?)[\"']"
         ],
-        "versioningTemplate": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)(\\.(?<patch>\\d+)))?$"
+        "versioningTemplate": "regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
       },
       {
         "customType": "regex",


### PR DESCRIPTION
Via https://github.com/SpotOnInc/renovate-config/commit/5910fc0e8cfca02521dd00cf64aad842529dcbef
and
https://github.com/SpotOnInc/renovate-config/pull/66/commits/57a47e1a3f3cb75828fe4588272dbca574e5a020