### PR TITLE
feat: add custom managers for Renovate presets

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,11 +46,28 @@
   customManagers: [
     {
       customType: 'regex',
+      description: [
+        'Update `bfra-me/renovate-config` preset in README.md from GitHub tags.',
+      ],
       managerFilePatterns: ['/^(README|readme)\\.md$/'],
       matchStrings: [
         '"github>(?<depName>bfra-me\\/renovate-config)#(?<currentValue>.+?)"',
       ],
       datasourceTemplate: 'github-tags',
+    },
+    {
+      customType: 'regex',
+      description: [
+        'Update `microsoft/m365-renovate-config` preset from GitHub releases.',
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'microsoft/m365-renovate-config',
+      managerFilePatterns: ['/^default\\.json5$/'],
+      matchStrings: [
+        '[\'"]github>microsoft/m365-renovate-config#(?<currentValue>[^\'" \\n\\(]+)',
+        '[\'"]github>microsoft/m365-renovate-config:.*#(?<currentValue>[^\'" \\n\\(]+)',
+        '[\'"]github>microsoft/m365-renovate-config/.*#(?<currentValue>[^\'" \\n\\(]+)',
+      ],
     },
   ],
 }

--- a/default.json5
+++ b/default.json5
@@ -17,6 +17,8 @@
     'bfra-me/renovate-config//group/prettier.json5',
     'group:vite',
     'bfra-me/renovate-config//vendors/elstudio.json5',
+    'bfra-me/renovate-config:renovate-config.json5(bfra-me/renovate-config)',
+    'bfra-me/renovate-config:renovate-config.json5(microsoft/m365-renovate-config)',
   ],
 
   timezone: 'America/Phoenix',

--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -1,0 +1,25 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  customManagers: [
+    {
+      customType: 'regex',
+      description: [
+        'Update Renovate config preset {{arg0}} from GitHub releases.',
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: '{{arg0}}',
+      managerFilePatterns: [
+        '/^renovate\\.json5?$/',
+        '/^\\.github/renovate\\.json5?$/',
+        '/^\\.gitlab/renovate\\.json5?$/',
+        '/^\\.renovaterc\\.json$/',
+        '/^\\.renovaterc$/',
+      ],
+      matchStrings: [
+        '[\'"]github>{{arg0}}#(?<currentValue>[^\'" \\n\\(]+)',
+        '[\'"]github>{{arg0}}:.*#(?<currentValue>[^\'" \\n\\(]+)',
+        '[\'"]github>{{arg0}}/.*#(?<currentValue>[^\'" \\n\\(]+)',
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
- Introduce custom manager for updating `bfra-me/renovate-config` preset from GitHub tags in README.md.
- Add custom manager for updating `microsoft/m365-renovate-config` preset from GitHub releases.
- Create new `renovate-config.json5` file to define custom managers.